### PR TITLE
Add explosion animation and save frame on mouse release

### DIFF
--- a/Assignments/Assignment-05-an-explosion.pde
+++ b/Assignments/Assignment-05-an-explosion.pde
@@ -24,30 +24,36 @@ void draw() {
     }
 }
 
+// Create an explosion on mouse pressed
 void mousePressed() {
     resetExplosion();
     createParticle(mouseX, mouseY, 50);
 }
 
+// Save the frame on mouse released
 void mouseReleased() {
     saveFrame("task_5_explosion.tif");
 }
 
+// Reset the explosion
 void resetExplosion() {
     particles.clear();
 }
 
+// Create a particle
 void createParticle(float x, float y, int count) {
     for (int i = 0; i < count; i++) {
         particles.add(new Particle(x, y));
     }
 }
 
+// Particle class
 class Particle {
     float x, y;
     float size;
     float velocityX, velocityY;
 
+    // Constructor
     Particle(float x, float y) {
         this.x = x;
         this.y = y;
@@ -56,6 +62,7 @@ class Particle {
         this.velocityY = random(-5, 5);
     }
 
+    // Update the particle
     void update() {
         x += velocityX;
         y += velocityY;
@@ -63,6 +70,7 @@ class Particle {
         size = min(size, maxParticleSize);
     }
 
+    // Display the particle
     void display() {
         ellipse(x, y, size, size);
     }

--- a/Assignments/Assignment-05-an-explosion.pde
+++ b/Assignments/Assignment-05-an-explosion.pde
@@ -1,29 +1,8 @@
-// # Task 5: An Explosion
-
-// ## Overview
-// Write a Processing sketch that demonstrates a simple explosion effect based on the guidelines and conditions specified below.
-
-// ## Conditions
-// - **Drawing Area**: The size of the drawing area is 640x480px.
-// - **Initial State**: Initially, the drawing area is blank, either a homogeneous color or with a simple background drawing.
-// - **Explosion Trigger**: On mouse click, a large number of simple shapes (preferably circles) appear at the mouse tip.
-// - **Shape Behavior**: The shapes fly out in random directions from the mouse tip.
-// - **Size Increase**: As long as the mouse is pressed, the shapes gradually increase in size until they reach a predetermined maximum size.
-// - **Post-Release**: Once the mouse is released, the shapes maintain their size and continue their trajectory.
-// - **Screenshot**: A screenshot is saved when the mouse is released.
-// - **Shape Exit**: The shapes are allowed to leave the drawing area without border handling.
-// - **Reset Mechanism**: Clicking the mouse again resets the explosion, clearing any shapes from the previous explosion.
-
-// ## Additional Instructions
-// - **Comments**: Properly comment your sketch (refer to `02_Comments_Variables.pdf` for guidelines).
-// - **Code Style**: Follow the established code style rules for exercise performance (details in `05_CodeStyle_Debugging.pdf`).
-// - **File Naming**: Name your Processing sketch `task_5_explosion.pde` and the screenshot/image `task_5_explosion.tif`.
-// - **Submission**: Submit your sketch (.pde) and image (.tif) via iLearn.
-// - **Due Date**: `Tuesday, 2023-11-28, 23:00`.
-
-// Instructor: Markus Mayer  
-// Contact: markus.mayer@th-deg.de  
-// Date: November 14, 2023
+// Task 5: An Explosion
+// Description: Create an explosion of particles when the mouse is pressed.
+// Author: Alex Rudaev
+// Date: 28/11/2023
+// References: https://github.com/THD-AI-2023/AIN-B-1-Programming-1-WS23/issues/15
 
 
 // Global variables

--- a/Assignments/Assignment-05-an-explosion.pde
+++ b/Assignments/Assignment-05-an-explosion.pde
@@ -27,23 +27,41 @@
 
 
 // Global variables
-// TODO: Add your global variables here
+ArrayList<Particle> particles;
+float maxParticleSize = 20;
 
 void setup() {
     size(640, 480);
     background(255);
+    particles = new ArrayList<Particle>();
 }
 
 void draw() {
-    // TODO: Add your drawing code here
+    background(255);
+    for (int i = 0; i < particles.size(); i++) {
+        Particle p = particles.get(i);
+        p.update();
+        p.display();
+    }
 }
 
 void mousePressed() {
-    // TODO: Add your mouse pressed code here
+    resetExplosion();
+    createParticle(mouseX, mouseY, 50);
 }
 
 void mouseReleased() {
-    // TODO: Add your mouse released code here
+    saveFrame("task_5_explosion.tif");
+}
+
+void resetExplosion() {
+    particles.clear();
+}
+
+void createParticle(float x, float y, int count) {
+    for (int i = 0; i < count; i++) {
+        particles.add(new Particle(x, y));
+    }
 }
 
 class Particle {

--- a/Assignments/Assignment-05-an-explosion.pde
+++ b/Assignments/Assignment-05-an-explosion.pde
@@ -65,17 +65,26 @@ void createParticle(float x, float y, int count) {
 }
 
 class Particle {
-    // TODO: Define class variables here
+    float x, y;
+    float size;
+    float velocityX, velocityY;
 
-    Particle() {
-        // TODO: Add your constructor code here
+    Particle(float x, float y) {
+        this.x = x;
+        this.y = y;
+        this.size = random(5, maxParticleSize);
+        this.velocityX = random(-5, 5);
+        this.velocityY = random(-5, 5);
     }
 
     void update() {
-        // TODO: Add your update code here
+        x += velocityX;
+        y += velocityY;
+        size += 0.1;
+        size = min(size, maxParticleSize);
     }
 
     void display() {
-        // TODO: Add your display code here
+        ellipse(x, y, size, size);
     }
 }

--- a/Assignments/Assignment-05-an-explosion.pde
+++ b/Assignments/Assignment-05-an-explosion.pde
@@ -1,0 +1,63 @@
+// # Task 5: An Explosion
+
+// ## Overview
+// Write a Processing sketch that demonstrates a simple explosion effect based on the guidelines and conditions specified below.
+
+// ## Conditions
+// - **Drawing Area**: The size of the drawing area is 640x480px.
+// - **Initial State**: Initially, the drawing area is blank, either a homogeneous color or with a simple background drawing.
+// - **Explosion Trigger**: On mouse click, a large number of simple shapes (preferably circles) appear at the mouse tip.
+// - **Shape Behavior**: The shapes fly out in random directions from the mouse tip.
+// - **Size Increase**: As long as the mouse is pressed, the shapes gradually increase in size until they reach a predetermined maximum size.
+// - **Post-Release**: Once the mouse is released, the shapes maintain their size and continue their trajectory.
+// - **Screenshot**: A screenshot is saved when the mouse is released.
+// - **Shape Exit**: The shapes are allowed to leave the drawing area without border handling.
+// - **Reset Mechanism**: Clicking the mouse again resets the explosion, clearing any shapes from the previous explosion.
+
+// ## Additional Instructions
+// - **Comments**: Properly comment your sketch (refer to `02_Comments_Variables.pdf` for guidelines).
+// - **Code Style**: Follow the established code style rules for exercise performance (details in `05_CodeStyle_Debugging.pdf`).
+// - **File Naming**: Name your Processing sketch `task_5_explosion.pde` and the screenshot/image `task_5_explosion.tif`.
+// - **Submission**: Submit your sketch (.pde) and image (.tif) via iLearn.
+// - **Due Date**: `Tuesday, 2023-11-28, 23:00`.
+
+// Instructor: Markus Mayer  
+// Contact: markus.mayer@th-deg.de  
+// Date: November 14, 2023
+
+
+// Global variables
+// TODO: Add your global variables here
+
+void setup() {
+    size(640, 480);
+    background(255);
+}
+
+void draw() {
+    // TODO: Add your drawing code here
+}
+
+void mousePressed() {
+    // TODO: Add your mouse pressed code here
+}
+
+void mouseReleased() {
+    // TODO: Add your mouse released code here
+}
+
+class Particle {
+    // TODO: Define class variables here
+
+    Particle() {
+        // TODO: Add your constructor code here
+    }
+
+    void update() {
+        // TODO: Add your update code here
+    }
+
+    void display() {
+        // TODO: Add your display code here
+    }
+}


### PR DESCRIPTION
This pull request adds an explosion animation to the sketch when the mouse is pressed. It also saves a frame of the explosion when the mouse is released. The Particle class constructor and update method have been refactored for improved functionality. Additionally, comments have been added to the functions and classes for better code readability.